### PR TITLE
Update docker-compose and Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:latest as builder
 
 RUN go get github.com/golang/dep/cmd/dep
 
@@ -8,8 +8,8 @@ COPY . .
 RUN dep ensure
 RUN CGO_ENABLED=0 GOOS=linux go install .
 
-FROM alpine:latest
+FROM alpine:latest as prod
 RUN mkdir /config
 WORKDIR /root/
-COPY --from=0 /go/bin/drawbridge .
+COPY --from=builder /go/bin/drawbridge .
 CMD ["./drawbridge", "/config/config.yaml"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+DEV_IMAGE := drawbridge
 DOCKER_COMPOSE ?= $(shell which docker-compose)
-DOCKER_COMPOSE_RUN := $(DOCKER_COMPOSE) run --rm drawbridge
+DOCKER_COMPOSE_DEV_RUN := $(DOCKER_COMPOSE) run --rm $(DEV_IMAGE)
 
 .SILENT: help
 help: ## Show this help message
@@ -11,26 +12,21 @@ help: ## Show this help message
 build-image: ## Build the docker image
 	$(DOCKER_COMPOSE) build
 
-install: build-image ## Install dependencies
-	$(DOCKER_COMPOSE) build
-	$(DOCKER_COMPOSE_RUN) glide install
-	$(DOCKER_COMPOSE_RUN) go install
-
 update: ## Update dependencies
 	rm -rf vendor
-	$(DOCKER_COMPOSE_RUN) glide update
+	$(DOCKER_COMPOSE_DEV_RUN) dep ensure
 
-glide-get: ## Add a new dependency to glide.yaml
-	$(DOCKER_COMPOSE_RUN) glide get ${pkg}
+dep-add: ## Add a new dependency to Gopkg.lock
+	$(DOCKER_COMPOSE_DEV_RUN) dep ensure -add ${pkg}
 
 build: ## Build and compile the source
-	$(DOCKER_COMPOSE_RUN) go build -o bin/drawbridge # This will go into /go/src/drawbridge/bin
+	$(DOCKER_COMPOSE_DEV_RUN) go build -o bin/drawbridge # This will go into /go/src/drawbridge/bin
 
-start: ## Start the service
-	$(DOCKER_COMPOSE) up
+start: ## Start the dev service
+	$(DOCKER_COMPOSE) run --service-ports --rm $(DEV_IMAGE) /go/bin/drawbridge /config/config.yaml
 
 test: ## Run the tests
-	$(DOCKER_COMPOSE_RUN) go test
+	$(DOCKER_COMPOSE_DEV_RUN) go test
 
 .PHONY: clean
 clean: ## Clean up any containers and images

--- a/README.md
+++ b/README.md
@@ -31,16 +31,22 @@ If the drawbridge server was running at localhost:5000, http://localhost:5000/ty
 The project includes a Docker Compose file and some useful targets in the Makefile to allow you to easily set up a
 development environment.
 
-To prepare the image for development, use `make install`.
+To prepare the image for development, use `make build-image`.
 
 ```bash
-$ make install
+$ make build-image
 ```
 
 This will build the docker image and then install dependencies with the mounted volumes.
 
-Even though Glide dependencies are installed when the Docker image is built, they must be installed again when developing because the volume mount will overwrite the /vendor directory in the container.
-Notice that after running `make install`, you have a local `vendor/` directory. Please do not commit this directory to git.
+The image contains two stages: 
+- `builder` with go installed
+- `prod` with only compiled version.
+
+To build the dev image use `make build-image`.
+
+Even though `dep` dependencies are installed when the Docker image is built, they must be installed again when developing because the volume mount will overwrite the /vendor directory in the container.
+Notice that after running `make update`, you have a local `vendor/` directory. Please do not commit this directory to git.
 
 Similarly, the application must be compiled again when using the development volume mounts. This is easy using `make build`.
 Once compiled, the application can be run using `make start`.
@@ -48,7 +54,7 @@ These can be combined into `make build start`.
 A normal development workflow might look like
 
 ```Shell
-$ make install
+$ make update
 $ make build start
 $ Ctrl+c
 [make some code changes]
@@ -59,10 +65,10 @@ Where `Ctrl+c` stops the running Docker container.
 
 ### Installing new packages
 
-If, during development, you need to use a new package that has not been previously installed, use `make glide-get`.
+If, during development, you need to use a new package that has not been previously installed, use `make dep-add`.
 
 ```bash
-$ make glide-get pkg=[package name]
+$ make dep-add pkg=[package name]
 ```
 
-For example, to add the `github.com/fsnotify/fsnotify` package, run `make glide-get pkg=github.com/fsnotify/fsnotify`.
+For example, to add the `github.com/fsnotify/fsnotify` package, run `make dep-add pkg=github.com/fsnotify/fsnotify`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,13 @@
-version: '3'
+version: '3.4'
 
 services:
   drawbridge:
-    build: .
-    image: jakewright/drawbridge
+    build:
+      context: .
+      target: builder
+    image: jakewright/drawbridge-dev
     volumes:
       - ./config.sample.yaml:/config/config.yaml
+      - .:/go/src/github.com/jakewright/drawbridge
     ports:
       - 8080:8080


### PR DESCRIPTION
I noticed that README and Makefile are outdated, `glide` is not used anymore, `dep` is used.
Also the Makefile commands were not working because the only image that is built is the minimal `alpine` image without `go` installed.

So:
- Updating README to reflect the current state of the project
- Using `builder` image instead of `alpine` one for local development with `docker-compose.yml`

I am not sure what is the current state of the project, but I like it as it's pretty simple and useful for building proof of concepts. Basically, for me it looks like a very minimalistic and simple version of [Kong API Gateway](https://konghq.com/kong/), for example. I would like to use this project for my local testing. 
And also planning to create a PR with the new plugin (JWT authorizer) soon.
I just started getting more familiar with Go as my main language is Python and drawbridge seems like a very good project to get hands on experience. Thanks!